### PR TITLE
uninstall non-fatal error

### DIFF
--- a/dxvk.go
+++ b/dxvk.go
@@ -139,7 +139,11 @@ func DxvkUninstall() {
 			log.Println("Removing DLL:", dllFile)
 
 			if err := os.Remove(dllFile); err != nil {
-				log.Fatal(err)
+				if os.IsNotExist(err) {
+					log.Print(err)
+				} else {
+					log.Fatal(err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
don't exit for non-fatal error:
`os.Remove(...)` on nonexistent file